### PR TITLE
feat: use attu svc port variable in template

### DIFF
--- a/charts/milvus/templates/attu-svc.yaml
+++ b/charts/milvus/templates/attu-svc.yaml
@@ -34,7 +34,7 @@ spec:
   ports:
     - name: attu
       protocol: TCP
-      port: 3000
+      port: {{ .Values.attu.service.port }}
       targetPort: 3000
   selector:
 {{ include "milvus.matchLabels" . | indent 4 }}


### PR DESCRIPTION
## What this PR does / why we need it:

The [default values file](https://github.com/milvus-io/milvus-helm/blob/405dd7b38cfb38cf3eec91971983d763551d9640/charts/milvus/values.yaml#L408) has a `port` field, which is never used. This PR makes the `attu-svc` template use the specified value.

This enables setting the port for Attu exposition to any value. The current behavior ignores what is given in the values file and always uses `3000`.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [X] PR only contains changes for one chart
